### PR TITLE
undefined method `to_json' for []:Array in pm2.json.erb

### DIFF
--- a/templates/pm2.json.erb
+++ b/templates/pm2.json.erb
@@ -1,7 +1,7 @@
 {
   "name":   "<%= @name %>",
   "script":    "<%= "#{@path}/current/node_modules/#{@name}/#{@script}" %>",
-  "args":   "<%= @args.to_a.to_json.gsub('"', "'") %>",
+  "args":   "<%= @args || @args.to_a.to_json.gsub('"', "'") %>",
   "env":    <%= @env || {}.to_json  %>,
   "error_file" : "/var/log/pm2/<%= @name %>/error.log",
   "out_file"   : "/var/log/pm2/<%= @name %>/out.log",


### PR DESCRIPTION
Had an issue where no args are defined that threw the following error:

==> node:   Filepath: /tmp/vagrant-puppet-2/modules-0/pm2/templates/pm2.json.erb
==> node:   Line: 4
==> node:   Detail: undefined method `to_json' for []:Array
==> node:  at /tmp/vagrant-puppet-2/modules-0/pm2/manifests/create_app.pp:57

Fixed it by ensuring it uses the defined default variable if exists otherwise parse it.

Might also need to add require json somehwere which I added to my vagrant file. Am new to puppet/ruby - any pointers would be appreciated.
